### PR TITLE
[Feature] RotateTile에서 플레이어 회전 제한

### DIFF
--- a/Prototype-Pummel Party/Assets/Scripts/Dice.cs
+++ b/Prototype-Pummel Party/Assets/Scripts/Dice.cs
@@ -8,6 +8,6 @@ public class Dice
     {
         int num = Random.Range(-1, 4);
         Debug.Log($"주사위 결과: {num}");
-        return 3;
+        return num;
     }
 }

--- a/Prototype-Pummel Party/Assets/Scripts/Dice.cs
+++ b/Prototype-Pummel Party/Assets/Scripts/Dice.cs
@@ -8,6 +8,6 @@ public class Dice
     {
         int num = Random.Range(-1, 4);
         Debug.Log($"주사위 결과: {num}");
-        return num;
+        return 3;
     }
 }

--- a/Prototype-Pummel Party/Assets/Scripts/Player/PlayerController.cs
+++ b/Prototype-Pummel Party/Assets/Scripts/Player/PlayerController.cs
@@ -179,6 +179,11 @@ public class PlayerController : MonoBehaviour
     // 이동하기 위해 목적지 타일 방향으로 회전
     private async UniTask<bool> LookNextDestTile(Vector3 dir)
     {
+        if(_currentTile.CompareTag("RotationTile"))
+        {
+            return true;
+        }
+
         Quaternion start = transform.rotation;
         Quaternion end = Quaternion.LookRotation(dir);
 


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 코드 컨벤션은 지켰나요?
- [x] 폴더구조는 지켰나요?
- [x] 실행했을 때, 오류는 없나요?


# 변경된 기능
RotateTile에서 플레이어 회전 제한

# 제안 사항
- _currentTile의 Tag를 확인하여 RotateTile인 경우 목적지 타일을 위해 회전하는 메소드를 실행하지 않고 반환

# (선택)스크린샷
![playerturnonrotateTile](https://github.com/ImmortalSprout-Prototype-TestVersion/Test-PummelParty/assets/74064375/3b300d87-58d4-4231-bc9b-5fb63efb1258)
